### PR TITLE
Add support to add and subtract other periods of time

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,21 +57,24 @@ moment.fn.businessDiff = function(param) {
     return signal * (weeks * 5 + start_offset + end_offset);
 };
 
-moment.fn.businessAdd = function(days) {
-    var signal = days < 0 ? -1 : 1;
-    var daysRemaining = Math.abs(days);
-    var d = this.clone();
-    while (daysRemaining) {
-      d.add(signal, 'd');
-      if (d.isBusinessDay()) {
-        daysRemaining--;
-      };
-    };
-    return d;
+moment.fn.businessAdd = function(number, period = 'days') {
+    var day = this.clone();
+    var signal = number < 0 ? -1 : 1;
+    var remaining = Math.abs(number);
+
+    while (remaining) {
+      day.add(signal, period);
+
+      if (day.isBusinessDay()) {
+        remaining--;
+      }
+    }
+
+    return day;
 };
 
-moment.fn.businessSubtract = function(days) {
-    return this.businessAdd(-days);
+moment.fn.businessSubtract = function(number, period = 'days') {
+    return this.businessAdd(-number, period);
 };
 
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -79,7 +79,7 @@ describe('Moment Business Days', function () {
 
         afterEach(resetLocale);
 
-        describe('On Tuesday, Novemeber 3rd 2015', function () {
+        describe('On Tuesday, November 3rd 2015', function () {
             it('adds business days only, excluding weekends, even over 2 weeks ', function (done) {
                 var newBusinessDay = moment('11-03-2015', 'MM-DD-YYYY').businessAdd(5);
                 expect(newBusinessDay.format('D')).to.eql('10');
@@ -88,6 +88,11 @@ describe('Moment Business Days', function () {
             it('adds business days only, excluding weekends ', function (done) {
                 var newBusinessDay = moment('11-03-2015', 'MM-DD-YYYY').businessAdd(10);
                 expect(newBusinessDay.format('D')).to.eql('17');
+                done();
+            });
+            it('adds business hours only, excluding weekends ', function (done) {
+                var newBusinessDay = moment('11-06-2015', 'MM-DD-YYYY').businessAdd(36, 'hours');
+                expect(newBusinessDay.format('D')).to.eql('9');
                 done();
             });
             it('adds business days only, excluding weekends and holidays, if present', function (done) {


### PR DESCRIPTION
This PR adds the ability to add (and subtract) other periods to a date, instead of just adding `days`. 

Since `moment.js` has support for that, I think it makes sense to be able to the same with this business-day logic,  increasing a given date by an amount of minutes, hours, days, etc...

However, there are some edge cases:
- If we call `businessAdd(0)`, the current date is not checked if wether it's a business day or not.
- If we add periods larger than `days` (`weeks`, `months`, `years`), the check is only done in each iteration, instead of splitting it into a smaller period (e.g `days`), which may lead to some undesirable results.

@kalmecak WDYT?