### PR TITLE
Allow monthBusinessDays to calculate days so far

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,10 +99,10 @@ moment.fn.prevBusinessDay = function() {
     return this;
 };
 
-moment.fn.monthBusinessDays = function() {
+moment.fn.monthBusinessDays = function(partialEndDate) {
     var me = this.clone();
     var day = me.clone().startOf('month');
-    var end = me.clone().endOf('month');
+    var end = partialEndDate ? partialEndDate : me.clone().endOf('month');
     var daysArr = [];
     var done = false;
     while (!done) {


### PR DESCRIPTION
By passing a moment object in as partialEndDate, you can calculate business days in a month up to that date.

For example, I needed to know if we are analyzing the month we are in, how many business days have occurred up until today. I can pass in moment() and determine that.

I needed the array result so I can compare to employee schedules which is why businessDaysIntoMonth didn't work for me.