### PR TITLE
Fix manipulation of invalid moment objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,9 @@ moment.fn.prevBusinessDay = function () {
 };
 
 moment.fn.monthBusinessDays = function (partialEndDate) {
+  if (!this.isValid()) {
+    return [];
+  }
   var me = this.clone();
   var day = me.clone().startOf('month');
   var end = partialEndDate ? partialEndDate : me.clone().endOf('month');
@@ -136,6 +139,9 @@ moment.fn.monthBusinessDays = function (partialEndDate) {
 };
 
 moment.fn.monthNaturalDays = function (fromToday) {
+  if (!this.isValid()) {
+    return [];
+  }
   var me = this.clone();
   var day = fromToday ? me.clone() : me.clone().startOf('month');
   var end = me.clone().endOf('month');
@@ -151,6 +157,9 @@ moment.fn.monthNaturalDays = function (fromToday) {
 };
 
 moment.fn.monthBusinessWeeks = function (fromToday) {
+  if (!this.isValid()) {
+    return [];
+  }
   var me = this.clone();
   var day = fromToday ? me.clone() : me.clone().startOf('month');
   var end = me.clone().endOf('month');
@@ -177,6 +186,9 @@ moment.fn.monthBusinessWeeks = function (fromToday) {
 };
 
 moment.fn.monthNaturalWeeks = function (fromToday) {
+  if (!this.isValid()) {
+    return [];
+  }
   var me = this.clone();
   var day = fromToday ? me.clone() : me.clone().startOf('month');
   var end = me.clone().endOf('month');

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ moment.fn.isBusinessDay = function () {
 };
 
 moment.fn.businessDaysIntoMonth = function () {
+  if (!this.isValid()) {
+    return NaN;
+  }
   var businessDay = this.isBusinessDay() ? this : this.prevBusinessDay();
   var monthBusinessDays = businessDay.monthBusinessDays();
   var businessDaysIntoMonth;

--- a/index.js
+++ b/index.js
@@ -72,6 +72,9 @@ moment.fn.businessDiff = function (param) {
 
 moment.fn.businessAdd = function (number, period) {
   var day = this.clone();
+  if (!day.isValid()) {
+    return day;
+  }
   var signal = number < 0 ? -1 : 1;
   var remaining = Math.abs(number);
   period = typeof period !== 'undefined' ? period : 'days';

--- a/tests/test.js
+++ b/tests/test.js
@@ -140,6 +140,18 @@ describe('Moment Business Days', function () {
   describe('.businessAdd', function () {
     afterEach(resetLocale);
 
+    describe('When moment object is invalid', function () {
+      it('should return a new invalid moment object', function (done) {
+        var originalMoment = moment(null);
+        var newBusinessDay = originalMoment.businessAdd(3);
+        // Deepy equal but not strictly equal
+        expect(originalMoment).to.eql(newBusinessDay);
+        expect(originalMoment).not.equal(newBusinessDay);
+        // New moment object should also be invalid
+        expect(newBusinessDay.isValid()).to.be.false;
+        done();
+      });
+    });
     describe('On Tuesday, November 3rd 2015', function () {
       it('adds business days only, excluding weekends, even over 2 weeks ', function (done) {
         var newBusinessDay = moment('11-03-2015', 'MM-DD-YYYY').businessAdd(5);

--- a/tests/test.js
+++ b/tests/test.js
@@ -200,7 +200,7 @@ describe('Moment Business Days', function () {
         workingWeekdays: [0, 1, 2, 3, 4, 5, 6]
       });
       var diff = moment('06-18-2017', 'MM-DD-YYYY').businessDiff(
-        moment('05-18-2017')
+        moment('05-18-2017', 'MM-DD-YYYY')
       );
       expect(diff).to.eql(31);
     });

--- a/tests/test.js
+++ b/tests/test.js
@@ -230,4 +230,27 @@ describe('Moment Business Days', function () {
       expect(diff).to.eql(0);
     });
   });
+  describe('Aggregate functions return empty array on invalid object', function () {
+    afterEach(resetLocale);
+    it('Should return empty array on .monthBusinessDays', function (done) {
+      var monthBusinessDays = moment(null).monthBusinessDays();
+      expect(monthBusinessDays).to.be.an('array').that.is.empty;
+      done();
+    });
+    it('Should return empty array on .monthNaturalDays', function (done) {
+      var monthNaturalDays = moment(null).monthNaturalDays();
+      expect(monthNaturalDays).to.be.an('array').that.is.empty;
+      done();
+    });
+    it('Should return empty array on .monthBusinessWeeks', function (done) {
+      var monthBusinessWeeks = moment(null).monthBusinessWeeks();
+      expect(monthBusinessWeeks).to.be.an('array').that.is.empty;
+      done();
+    });
+    it('Should return empty array on .monthNaturalWeeks', function (done) {
+      var monthNaturalWeeks = moment(null).monthNaturalWeeks();
+      expect(monthNaturalWeeks).to.be.an('array').that.is.empty;
+      done();
+    });
+  });
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -196,7 +196,7 @@ describe('Moment Business Days', function () {
       expect(diff).to.eql(6);
     });
     it('Should calculate nr of business with all working days', function () {
-      moment.locale('us', {
+      moment.updateLocale('us', {
         workingWeekdays: [0, 1, 2, 3, 4, 5, 6]
       });
       var diff = moment('06-18-2017', 'MM-DD-YYYY').businessDiff(

--- a/tests/test.js
+++ b/tests/test.js
@@ -104,6 +104,13 @@ describe('Moment Business Days', function () {
   describe('.businessDaysIntoMonth', function () {
     afterEach(resetLocale);
 
+    describe('When moment object is invalid', function () {
+      it('should return NaN', function (done) {
+        var businessDaysIntoMonth = moment(null).businessDaysIntoMonth();
+        expect(businessDaysIntoMonth).to.be.NaN;
+        done();
+      });
+    });
     describe('On Wednesday, September 23rd 2015', function () {
       it('should be 17 when there are no holidays', function (done) {
         moment.updateLocale('us', {

--- a/tests/test.js
+++ b/tests/test.js
@@ -105,10 +105,9 @@ describe('Moment Business Days', function () {
     afterEach(resetLocale);
 
     describe('When moment object is invalid', function () {
-      it('should return NaN', function (done) {
+      it('should return NaN', function () {
         var businessDaysIntoMonth = moment(null).businessDaysIntoMonth();
         expect(businessDaysIntoMonth).to.be.NaN;
-        done();
       });
     });
     describe('On Wednesday, September 23rd 2015', function () {
@@ -141,7 +140,7 @@ describe('Moment Business Days', function () {
     afterEach(resetLocale);
 
     describe('When moment object is invalid', function () {
-      it('should return a new invalid moment object', function (done) {
+      it('should return a new invalid moment object', function () {
         var originalMoment = moment(null);
         var newBusinessDay = originalMoment.businessAdd(3);
         // Deepy equal but not strictly equal
@@ -149,7 +148,6 @@ describe('Moment Business Days', function () {
         expect(originalMoment).not.equal(newBusinessDay);
         // New moment object should also be invalid
         expect(newBusinessDay.isValid()).to.be.false;
-        done();
       });
     });
     describe('On Tuesday, November 3rd 2015', function () {
@@ -232,25 +230,21 @@ describe('Moment Business Days', function () {
   });
   describe('Aggregate functions return empty array on invalid object', function () {
     afterEach(resetLocale);
-    it('Should return empty array on .monthBusinessDays', function (done) {
+    it('Should return empty array on .monthBusinessDays', function () {
       var monthBusinessDays = moment(null).monthBusinessDays();
       expect(monthBusinessDays).to.be.an('array').that.is.empty;
-      done();
     });
-    it('Should return empty array on .monthNaturalDays', function (done) {
+    it('Should return empty array on .monthNaturalDays', function () {
       var monthNaturalDays = moment(null).monthNaturalDays();
       expect(monthNaturalDays).to.be.an('array').that.is.empty;
-      done();
     });
-    it('Should return empty array on .monthBusinessWeeks', function (done) {
+    it('Should return empty array on .monthBusinessWeeks', function () {
       var monthBusinessWeeks = moment(null).monthBusinessWeeks();
       expect(monthBusinessWeeks).to.be.an('array').that.is.empty;
-      done();
     });
-    it('Should return empty array on .monthNaturalWeeks', function (done) {
+    it('Should return empty array on .monthNaturalWeeks', function () {
       var monthNaturalWeeks = moment(null).monthNaturalWeeks();
       expect(monthNaturalWeeks).to.be.an('array').that.is.empty;
-      done();
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/kalmecak/moment-business-days/issues/43
- Prevents infinite loops
- Adds unit tests for touched methods

Currently, `.businessDiff()` returns 0 if either of the moment objects is invalid. I left that behavior alone since returning `NaN` would possibly constitute a breaking change.