### PR TITLE
Add `relative` option parameter to `businessDiff`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ var diff = moment('05-15-2017', 'MM-DD-YYYY').businessDiff(moment('05-08-2017','
 // diff = 5
 ```
 
+Note that the default behavior of `businessDiff` is to return an **absolute** value,
+which is a departure from moment's `diff`. To match the behavior of `diff` pass
+`true` as the second argument to `businessDiff`:
+
+```javascript
+var diff = moment('05-08-2017', 'MM-DD-YYYY').businessDiff(moment('05-15-2017','MM-DD-YYYY'), true);
+// diff = -5
+```
+
 #### `.businessAdd(days)` => Moment
 
 Will add the given number of days skipping business days, returning a **Moment.js** object:

--- a/index.js
+++ b/index.js
@@ -48,9 +48,10 @@ moment.fn.businessDaysIntoMonth = function () {
   return businessDaysIntoMonth;
 };
 
-moment.fn.businessDiff = function (param) {
+moment.fn.businessDiff = function (param, relative) {
   var d1 = this.clone();
   var d2 = param.clone();
+  var positive = d1 >= d2;
   var start = d1 < d2 ? d1 : d2;
   var end = d2 > d1 ? d2 : d1;
 
@@ -65,6 +66,10 @@ moment.fn.businessDiff = function (param) {
       daysBetween++;
     }
     start.add(1, 'd');
+  }
+
+  if (relative) {
+    return positive ? daysBetween : -daysBetween;
   }
 
   return daysBetween;

--- a/tests/test.js
+++ b/tests/test.js
@@ -203,6 +203,19 @@ describe('Moment Business Days', function () {
       );
       expect(diff).to.eql(5);
     });
+    it('Should be negative if start is after end and relative is true', function () {
+      var diff = moment('05-08-2017', 'MM-DD-YYYY').businessDiff(
+        moment('05-15-2017', 'MM-DD-YYYY'),
+        true
+      );
+      expect(diff).to.eql(-5);
+    });
+    it('Should be positive if start is after end and relative is false', function () {
+      var diff = moment('05-08-2017', 'MM-DD-YYYY').businessDiff(
+        moment('05-15-2017', 'MM-DD-YYYY')
+      );
+      expect(diff).to.eql(5);
+    });
     it('Should calculate nr of business days with custom workingdays', function () {
       moment.updateLocale('us', {
         workingWeekdays: [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
Fixes #32.

**This changes behavior of `businessDiff`, and may break existing code which relies on current behavior.** As this PR stands and according to semver, this may constitute a **major version bump**. Maybe this could instead be implemented under an alternate function name or as an option to `businessDiff` until a major version comes around?

The goal here is to bring the behavior of `businessDiff` in-line with the behavior of moment's `diff`, as specified [here](https://momentjs.com/docs/#/displaying/difference/):

>If the moment is earlier than the moment you are passing to moment.fn.diff, the return value will be negative.