### PR TITLE
Update definitions file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'moment' {
         isHoliday: () => boolean;
         isBusinessDay: () => boolean;
 
-        businessDaysIntoMonth: () => Moment;
+        businessDaysIntoMonth: () => number;
 
         businessDiff: (param: Moment) => number;
         businessAdd: (param: number, period?: unitOfTime.Base) => Moment;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,3 +25,5 @@ declare module 'moment' {
         holidayFormat?: string;
     }
 }
+
+export = moment;


### PR DESCRIPTION
Export type definitions so that requiring `moment-business-days` **instead of** `moment` will still serve all the definitions to TypeScript.

Also, fix `businessDaysIntoMonth()` return value.