### PR TITLE
Add ability to search beyond 7 days for next/previous business days

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ moment('30-01-2015', 'DD-MM-YYYY').nextBusinessDay()._d // Mon Feb 02 2015 00:00
 moment('02-02-2015', 'DD-MM-YYYY').nextBusinessDay()._d //Tue Feb 03 2015 00:00:00 GMT-0600 (CST)
 ```
 
+By default only 7 days into the future are checked for the next business day. To search beyond 7 days
+set the nextBusinessDayLimit (as a number) higher.
+````javascript
+var moment = require('moment-business-days');
+
+moment.updateLocale('us', {
+   nextBusinessDayLimit: 31
+});
+````
+
 #### `.prevBusinessDay()` => Moment
 
 Will retrieve the previous business date as a **Moment.js** object:
@@ -130,6 +140,16 @@ moment('02-02-2015', 'DD-MM-YYYY').prevBusinessDay()._d // Fri Jan 30 2015 00:00
 // Previous business day of Tuesday 03-02-2015
 moment('03-02-2015', 'DD-MM-YYYY').prevBusinessDay()._d //Mon Feb 02 2015 00:00:00 GMT-0600 (CST)
 ```
+
+By default only the last 7 days are checked for the previous business day. To search beyond 7 days
+set the prevBusinessDayLimit (as a number) higher.
+````javascript
+var moment = require('moment-business-days');
+
+moment.updateLocale('us', {
+   prevBusinessDayLimit: 31
+});
+````
 
 #### `.monthBusinessDays()` => Moment[]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,8 @@ declare module 'moment' {
     interface LocaleSpecification {
         holidays?: string[];
         holidayFormat?: string;
+        nextBusinessDayLimit?: number;
+        prevBusinessDayLimit?: number;
         workingWeekdays?: number[];
     }
 }

--- a/index.js
+++ b/index.js
@@ -102,8 +102,11 @@ moment.fn.businessSubtract = function (number, period) {
 };
 
 moment.fn.nextBusinessDay = function () {
+  var locale = this.localeData();
+
   var loop = 1;
-  var limit = 7;
+  var defaultNextBusinessDayLimit = 7;
+  var limit = locale._nextBusinessDayLimit || defaultNextBusinessDayLimit;
   while (loop < limit) {
     if (this.add(1, 'd').isBusinessDay()) {
       break;
@@ -114,8 +117,11 @@ moment.fn.nextBusinessDay = function () {
 };
 
 moment.fn.prevBusinessDay = function () {
+  var locale = this.localeData();
+
   var loop = 1;
-  var limit = 7;
+  var defaultPrevBusinessDayLimit = 7;
+  var limit = locale._prevBusinessDayLimit || defaultPrevBusinessDayLimit;
   while (loop < limit) {
     if (this.subtract(1, 'd').isBusinessDay()) {
       break;

--- a/tests/test.js
+++ b/tests/test.js
@@ -4,7 +4,11 @@ var expect = require('chai').expect;
 var holidayFormat = 'MM-DD-YYYY';
 
 var resetLocale = function (done) {
-  moment.updateLocale('us', {});
+  moment.updateLocale('us', {
+    holidays: [],
+    holidayFormat: '',
+    workingWeekdays: [1,2,3,4,5],
+  });
   done();
 };
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -21,6 +21,25 @@ describe('Moment Business Days', function () {
         done();
       });
     });
+    describe('On April 10th, 2019', function () {
+      beforeEach(function (done) {
+        moment.updateLocale('us', {
+          holidays: ['04-05-2019', '04-06-2019', '04-07-2019', '04-08-2019', '04-09-2019'],
+          holidayFormat: 'MM-DD-YYYY',
+          workingWeekdays: [1],
+          prevBusinessDayLimit: 31,
+        });
+        done();
+      });
+
+      afterEach(resetLocale);
+
+      it('should be 1st when considering holidays and custom working days', function (done) {
+        var first = moment().prevBusinessDay();
+        expect(first.format('D')).to.eql('1');
+        done();
+      });
+    });
   });
   describe('.isBusinessDay', function () {
     describe('When today is a regular weekday', function () {


### PR DESCRIPTION
`nextBusinessDay` and `prevBusinessDay` only checked ahead and behind for a maximum of seven days for the next business day.

If a week has many holidays, this can lead to surprising effects: https://github.com/kalmecak/moment-business-days/issues/67