### PR TITLE
Get business weeks between two dates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare module 'moment' {
         monthNaturalDays(fromToday?: boolean): Moment[];
         monthBusinessWeeks(fromToday?: boolean): Moment[][];
         monthNaturalWeeks(fromToday?: boolean): Moment[][];
+        businessWeeksBetween(endDate: Moment): Moment[][];
     }
 
     interface LocaleSpecification {

--- a/index.js
+++ b/index.js
@@ -175,12 +175,25 @@ moment.fn.monthNaturalDays = function (fromToday) {
 };
 
 moment.fn.monthBusinessWeeks = function (fromToday) {
-  if (!this.isValid()) {
+  fromToday = fromToday || false;
+  var me = this.clone();
+  var startDate = fromToday ? me.clone() : me.clone().startOf('month');
+  return getBusinessWeeks(this, fromToday, null, startDate);
+};
+
+moment.fn.businessWeeksBetween = function (endDate) {
+  var me = this.clone();
+  var startDate = me.clone();
+  return getBusinessWeeks(this, false, endDate, startDate);
+};
+
+var getBusinessWeeks = function (self, fromToday, endDate, startDate) {
+  if (!self.isValid()) {
     return [];
   }
-  var me = this.clone();
-  var day = fromToday ? me.clone() : me.clone().startOf('month');
-  var end = me.clone().endOf('month');
+  var me = self.clone();
+  var day = startDate;
+  var end = endDate ? moment(endDate).clone() : me.clone().endOf('month');
   var weeksArr = [];
   var daysArr = [];
   var done = false;
@@ -201,7 +214,7 @@ moment.fn.monthBusinessWeeks = function (fromToday) {
     }
   }
   return weeksArr;
-};
+}
 
 moment.fn.monthNaturalWeeks = function (fromToday) {
   if (!this.isValid()) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -324,7 +324,11 @@ describe('Moment Business Days', function () {
       var businessWeeksBetween = moment(null).businessWeeksBetween();
       expect(businessWeeksBetween).to.be.an('array').that.is.empty;
     });
-    it('Should return array of weeks on .businessWeeksBetween', function () {
+    it('Should return array of business weeks on .monthBusinessWeeks', function () {
+      var monthBusinessWeeks = moment('2019-02-02').monthBusinessWeeks();
+      expect(monthBusinessWeeks).to.be.an('array').that.is.not.empty;
+    });
+    it('Should return array of business weeks on .businessWeeksBetween', function () {
       var businessWeeksBetween = moment('2019-02-02').businessWeeksBetween(moment('2019-04-02'));
       expect(businessWeeksBetween).to.be.an('array').that.is.not.empty;
     });

--- a/tests/test.js
+++ b/tests/test.js
@@ -320,5 +320,9 @@ describe('Moment Business Days', function () {
       var monthNaturalWeeks = moment(null).monthNaturalWeeks();
       expect(monthNaturalWeeks).to.be.an('array').that.is.empty;
     });
+    it('Should return empty array on .businessWeeksBetween', function () {
+      var businessWeeksBetween = moment(null).businessWeeksBetween();
+      expect(businessWeeksBetween).to.be.an('array').that.is.empty;
+    });
   });
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -324,5 +324,9 @@ describe('Moment Business Days', function () {
       var businessWeeksBetween = moment(null).businessWeeksBetween();
       expect(businessWeeksBetween).to.be.an('array').that.is.empty;
     });
+    it('Should return array of weeks on .businessWeeksBetween', function () {
+      var businessWeeksBetween = moment('2019-02-02').businessWeeksBetween(moment('2019-04-02'));
+      expect(businessWeeksBetween).to.be.an('array').that.is.not.empty;
+    });
   });
 });


### PR DESCRIPTION
This PR adds a new method `businessWeeksBetween` that allows users get business weeks between two dates.