### PR TITLE
fix: TS businessDiff signature include 'relative' param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module 'moment' {
 
         businessDaysIntoMonth(): number;
 
-        businessDiff(param: Moment): number;
+        businessDiff(param: Moment, relative?: boolean): number;
         businessAdd(param: number, period?: unitOfTime.Base): Moment;
         businessSubtract(param: number, period?: unitOfTime.Base): Moment;
 


### PR DESCRIPTION
Update *.d.ts for `businessDiff` to include `relative` param to match documentation and implementation in index.js.

https://github.com/kalmecak/moment-business-days#businessdiff--number